### PR TITLE
Added 429 too many request detection

### DIFF
--- a/dmax.py
+++ b/dmax.py
@@ -209,11 +209,9 @@ def main(showid, chosen_season=0, chosen_episode=0, realm=REALMS[0]):
             elif req.status_code == 429:
                 logger.info("Received 429 Too Many Requests. Waiting {0} seconds to cool down!".format(currentFetchAttempt * 10))
                 time.sleep(currentFetchAttempt * 10)
-                continue
 
             else:
                 logger.error("HTTP error code {0} for video id {1}. Skipping.".format(req.status_code, episode.id))
-                continue
 
         else:
             logger.error("Episode URL could not be fetched. Skipping")

--- a/dmax.py
+++ b/dmax.py
@@ -181,7 +181,7 @@ def main(showid, chosen_season=0, chosen_episode=0, realm=REALMS[0]):
         xls.worksheet.write(xls.row, xls.col(), episode.description)
         xls.worksheet.write(xls.row, xls.col(), filename)
 
-        fetchAttempts = [1,2,3]
+        fetchAttempts = range(1, 4, 1)
 
         for currentFetchAttempt in fetchAttempts:
             logger.info("Attempt {0} of {1}".format(currentFetchAttempt, len(fetchAttempts)))


### PR DESCRIPTION
The Discovery API has some rate limiting in place. I noticed it when attempting to fetch Moonshiners (ID 6009). After round about 40 episodes it started to throw HTTP 429 Too Many Requests responses. This resulted in skipped episodes in the xlsx file.

To counter this each episode is tried three times before skipping it. In case of a  HTTP 429 response the application sleeps for a couple of seconds (1st attempt: 10 seconds, 2nd attempt 20 seconds, etc).

Sample output:

> 2020-09-08 23:29:47,747 - DMAX - INFO - Getting link 46 of 97
> 2020-09-08 23:29:47,747 - DMAX - INFO - Attempt 1 of 3
> 2020-09-08 23:29:47,901 - DMAX - INFO - Received 429 Too Many Requests. Waiting 10 seconds to cool down!
> 2020-09-08 23:29:57,904 - DMAX - INFO - Attempt 2 of 3
> 2020-09-08 23:29:58,070 - DMAX - INFO - Received 429 Too Many Requests. Waiting 20 seconds to cool down!
> 2020-09-08 23:30:18,075 - DMAX - INFO - Attempt 3 of 3
> 2020-09-08 23:30:18,256 - DMAX - INFO - Getting link 47 of 97
> 2020-09-08 23:30:18,256 - DMAX - INFO - Attempt 1 of 3

Thanks for this application btw!
